### PR TITLE
GH-3 Improve error handling and reporting when requests fail.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -188,7 +188,7 @@ function getResultsTable( results, strategy ) {
 /**
  * Execute.
  */
- ( async () => {
+( async () => {
 	const config = getConfig();
 	const urlGroup = process.argv[3] || Object.keys( config.urls )[0];
 

--- a/cli.js
+++ b/cli.js
@@ -71,19 +71,19 @@ function writeResultsFile( fileName, resultsData ) {
  */
 async function runTests( url, strategy ) {
 	const config = getConfig();
-	const returnData = {
+	const defaultData = {
 		url,
 		strategy,
-		tests: {},
+		lighthouse: {},
 	};
 
 	const categories = Object.keys( config.categories );
 	if ( ! categories?.length ) {
-		return returnData;
+		return defaultData;
 	}
 
 	const testUrl = new URL( url );
-	Object.keys( config.searchParams ).forEach( param => {
+	Object.keys( config.searchParams || {} ).forEach( param => {
 		testUrl.searchParams.append( param, config.searchParams[ param ] );
 	} );
 
@@ -114,7 +114,7 @@ async function runTests( url, strategy ) {
 		response = await rawResponse.json();
 	} catch ( err ) {
 		console.error( colors.red( err.toString() ) );
-		return returnData;
+		return defaultData;
 	}
 
 	const { lighthouseResult } = response;
@@ -123,7 +123,7 @@ async function runTests( url, strategy ) {
 		console.error( colors.red( `Error. Failed to retrieve result for ${ testUrl.toString() } - ${ strategy }` ) );
 		console.error( colors.red( `${ requestUrl.toString() }` ) );
 		console.error( response );
-		return returnData;
+		return defaultData;
 	}
 
 	writeResultsFile(
@@ -132,8 +132,8 @@ async function runTests( url, strategy ) {
 	);
 
 	return {
-		...returnData,
-		tests: Object.entries( lighthouseResult.categories ).reduce( ( scores, [ category, { score = 0 } ] ) => {
+		...defaultData,
+		lighthouse: Object.entries( lighthouseResult.categories ).reduce( ( scores, [ category, { score = 0 } ] ) => {
 			scores[ category ] = score * 100;
 			return scores;
 		}, {} ),
@@ -178,7 +178,7 @@ function getResultsTable( results, strategy ) {
 	results.forEach( ( result, index ) => {
 		table.push( [
 			urls[ index ],
-			...categories.map( ( [ category, { threshold } ] ) => formatResult( result.tests[ category ], threshold[ strategy ] ) ),
+			...categories.map( ( [ category, { threshold } ] ) => formatResult( result.lighthouse[ category ], threshold[ strategy ] ) ),
 		] );
 	} );
 
@@ -230,12 +230,20 @@ function getResultsTable( results, strategy ) {
 		console.log();
 
 		const { fail = 0, total = 0 } = results.reduce( ( tests, result ) => {
-			Object.entries( result.tests ).forEach( ( [ category, score ] ) => {
-				tests.total++;
-				if ( score < categories[ category ].threshold ) {
-					tests.fail++;
-				}
-			} );
+			const lighthouseResult = Object.entries( result.lighthouse );
+			if ( lighthouseResult.length === 0 ) {
+				// All category tests considered failed.
+				const totalCategories = Object.keys( categories ).length;
+				tests.fail += totalCategories;
+				tests.total += totalCategories;
+			} else {
+				lighthouseResult.forEach( ( [ category, score ] ) => {
+					tests.total++;
+					if ( score < categories[ category ].threshold[strategy] ) {
+						tests.fail++;
+					}
+				} );
+			}
 
 			return tests;
 		}, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@humanmade/bulk-lighthouse",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@humanmade/bulk-lighthouse",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "cli-table3": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humanmade/bulk-lighthouse",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Run bulk lighthouse tests using Google PageSpeed Insights API",
   "main": "cli.js",
   "scripts": {


### PR DESCRIPTION
GH-3 Improve error handling and reporting when requests fail.

This PR improves error handling so that the test results message and table accurately reflect when a request to test a URL has failed or when a test result is below the threshold for a particular strategy.

Note, there are some changes related to variable naming which seem to not be in the [main branch](https://github.com/humanmade/bulk-lighthouse/blob/4fc97f8ecc9ccf2906c050f136ddea153547bc17/cli.js#L74) but are in production via tag 1.0.2 as seen in this [commit](https://github.com/humanmade/bulk-lighthouse/commit/2e8dc8a60f8a1e7e4c727ca0874c6c12a20b23f2). Please let me know how to properly reconcile this issue if those variable naming changes are to be removed from this PR.

### Testing instructions

- Run the bulk-lighthouse script using the code in this PR and the summary message that is after the table of results should take into account failed requests. See issue description for more details.